### PR TITLE
Increase the "Base address" field's width and add support for ARM32 / ARM32Thumb Big-Endian mode

### DIFF
--- a/lib/re.c
+++ b/lib/re.c
@@ -55,7 +55,9 @@ int re_is_unicorn_supported(void) {
 
 static int re_open_ks(enum Arch arch, int opt, struct RetBuffer *err_buf, ks_engine **ks) {
 	ks_arch _ks_arch;
-	ks_mode _ks_mode = KS_MODE_LITTLE_ENDIAN;
+	ks_mode _ks_mode;
+	if (opt & RET_BIG_ENDIAN) _ks_mode = KS_MODE_BIG_ENDIAN;
+	else _ks_mode = KS_MODE_LITTLE_ENDIAN;
 	if (arch == ARCH_X86) {
 		_ks_arch = KS_ARCH_X86;
 		if (opt & RET_BITS_64) _ks_mode |= KS_MODE_64;
@@ -76,7 +78,6 @@ static int re_open_ks(enum Arch arch, int opt, struct RetBuffer *err_buf, ks_eng
 		if (opt & RET_RISCV_C) _ks_mode |= KS_MODE_RISCVC;
 	} else if (arch == ARCH_POWERPC) {
 		_ks_arch = KS_ARCH_PPC;
-		if (opt & RET_BIG_ENDIAN) _ks_mode = KS_MODE_BIG_ENDIAN; else _ks_mode = KS_MODE_LITTLE_ENDIAN;
 		_ks_mode |= KS_MODE_R_REG_SYNTAX;
 		if (opt & RET_BITS_64) _ks_mode |= KS_MODE_PPC64;
 		else if (opt & RET_BITS_32) _ks_mode |= KS_MODE_PPC32;

--- a/lib/re.c
+++ b/lib/re.c
@@ -115,7 +115,9 @@ static int re_open_ks(enum Arch arch, int opt, struct RetBuffer *err_buf, ks_eng
 
 static int re_open_cs(enum Arch arch, int opt, struct RetBuffer *err_buf, csh *cs) {
 	cs_arch _cs_arch = 0;
-	cs_mode _cs_mode = CS_MODE_LITTLE_ENDIAN;
+	cs_mode _cs_mode;
+	if (opt & RET_BIG_ENDIAN) _cs_mode = CS_MODE_BIG_ENDIAN;
+	else _cs_mode = CS_MODE_LITTLE_ENDIAN;
 	if (arch == ARCH_X86) {
 		_cs_arch = CS_ARCH_X86;
 		if (opt & RET_BITS_64) _cs_mode |= CS_MODE_64;
@@ -135,7 +137,6 @@ static int re_open_cs(enum Arch arch, int opt, struct RetBuffer *err_buf, csh *c
 		if (opt & RET_RISCV_C) _cs_mode |= CS_MODE_RISCVC;
 	} else if (arch == ARCH_POWERPC) {
 		_cs_arch = CS_ARCH_PPC;
-		if (opt & RET_BIG_ENDIAN) _cs_mode = CS_MODE_BIG_ENDIAN; else _cs_mode = CS_MODE_LITTLE_ENDIAN;		
 		if (opt & RET_BITS_64) _cs_mode |= CS_MODE_64;
 		else if (opt & RET_BITS_32) _cs_mode |= CS_MODE_32;
 	} else {

--- a/lib/unicorn.c
+++ b/lib/unicorn.c
@@ -78,9 +78,20 @@ int re_emulator(enum Arch arch, int opt, unsigned int base_addr, struct RetBuffe
 	log->clear(log);
 	uc_engine *uc;
 	uc_err err;
+	// By checking against opt instead of _uc_mode we can work around the fact that some UC_* flags are zero.
+	#define CHECK_NOT_SUPPORTED(flag, name) if (opt & (flag)) { \
+		buffer_appendf(log, name " is not supported in Unicorn Engine\n"); \
+		return -1; \
+	}
 
 	uc_arch _uc_arch = 0;
 	uc_mode _uc_mode = 0;
+
+	if (opt & RET_BIG_ENDIAN)
+		_uc_mode = UC_MODE_BIG_ENDIAN;
+	else
+		_uc_mode = UC_MODE_LITTLE_ENDIAN;
+
 	if (arch == ARCH_X86) {
 		_uc_arch = UC_ARCH_X86;
 		if (opt & RET_BITS_64) _uc_mode |= UC_MODE_64;
@@ -93,9 +104,11 @@ int re_emulator(enum Arch arch, int opt, unsigned int base_addr, struct RetBuffe
 	} else if (arch == ARCH_ARM32) {
 		_uc_arch = UC_ARCH_ARM;
 		_uc_mode |= UC_MODE_ARM;
+		CHECK_NOT_SUPPORTED(RET_BIG_ENDIAN, "Big Endian ARM32");
 	} else if (arch == ARCH_ARM32_THUMB) {
 		_uc_arch = UC_ARCH_ARM;
 		_uc_mode |= UC_MODE_THUMB;
+		CHECK_NOT_SUPPORTED(RET_BIG_ENDIAN, "Big Endian ARM32");
 	} else if (arch == ARCH_RISCV) {
 		_uc_arch = UC_ARCH_RISCV;
 		if (opt & RET_BITS_64) _uc_mode |= UC_MODE_RISCV64;
@@ -103,19 +116,15 @@ int re_emulator(enum Arch arch, int opt, unsigned int base_addr, struct RetBuffe
 		else _uc_mode |= UC_MODE_RISCV64;
 	} else if (arch == ARCH_POWERPC) {
 		_uc_arch = UC_ARCH_PPC;
-		if (opt & RET_BIG_ENDIAN) _uc_mode = UC_MODE_BIG_ENDIAN; else _uc_mode = UC_MODE_LITTLE_ENDIAN;
 		if (opt & RET_BITS_64) _uc_mode |= UC_MODE_PPC64;
 		else if (opt & RET_BITS_32) _uc_mode |= UC_MODE_PPC32;
 		else _uc_mode |= UC_MODE_PPC64;
-		if (!(_uc_mode & UC_MODE_BIG_ENDIAN)) {
-			buffer_appendf(log, "Little Endian PowerPC is not supported in Unicorn Engine\n");
-			return -1;
-		}
+		CHECK_NOT_SUPPORTED(RET_LITTLE_ENDIAN, "Little Endian PowerPC")
 	} else {
 		buffer_appendf(log, "Unknown architecture\n");
 		return -1;
 	}
-
+#undef CHECK_NOT_SUPPORTED
 	struct EmulatorState state = {
 		.arch = _uc_arch,
 		.log = log,

--- a/www/index.html
+++ b/www/index.html
@@ -97,7 +97,7 @@
 				<span>Examples</span><img class="icon" src="{{TOP_LEVEL}}/assets/arrow_drop_down_24dp_E3E3E3_FILL0_wght400_GRAD0_opsz48.png">
 				<div class="dropdown-content" id="examples-dropdown-box"></div>
 			</div>
-			<div class="btn btn-green" id="x86-dropdown">
+			<div class="btn btn-green archdep-custom-dropdown" id="x86-dropdown">
 				<span>x86 Options</span>
 				<div class="dropdown-content" id="x86-dropdown-box">
 					<span class="padded-block">X86 Syntax:</span>
@@ -112,7 +112,7 @@
 					<div class="radio-button" name="x86_bits">16</div>
 				</div>
 			</div>
-			<div class="btn btn-green" id="riscv-dropdown">
+			<div class="btn btn-green archdep-custom-dropdown" id="riscv-dropdown">
 				<span>RISC-V Options</span>
 				<div class="dropdown-content" id="riscv-dropdown-box">
 					<span class="padded-block">Bits:</span>
@@ -134,7 +134,7 @@
 					</div>
 				</div>
 			</div>
-			<div class="btn btn-green" id="ppc-dropdown">
+			<div class="btn btn-green archdep-custom-dropdown" id="ppc-dropdown">
 				<span>PowerPC Options</span>
 				<div class="dropdown-content" id="ppc-dropdown-box">
 					<span class="padded-block">Bits:</span>
@@ -144,6 +144,14 @@
 					<span class="padded-block">Endian:</span>
 					<div class="radio-button" name="ppc_endian">Big</div>
 					<div class="radio-button" name="ppc_endian">Little</div>
+				</div>
+			</div>
+			<div class="btn btn-green archdep-custom-dropdown" id="arm-dropdown">
+				<span>ARM Options</span>
+				<div class="dropdown-content" id="arm-dropdown-box">
+					<span class="padded-block">Endianness:</span>
+					<div class="radio-button" name="arm_endian">Big</div>
+					<div class="radio-button" name="arm_endian">Little</div>
 				</div>
 			</div>
 			<div class="btn" id="base-address-box">Base address: <input spellcheck="false" type="text" id="base-address" value="0x0"></div>

--- a/www/index.html
+++ b/www/index.html
@@ -149,7 +149,7 @@
 			<div class="btn btn-green archdep-custom-dropdown" id="arm-dropdown">
 				<span>ARM Options</span>
 				<div class="dropdown-content" id="arm-dropdown-box">
-					<span class="padded-block">Endianness:</span>
+					<span class="padded-block">Endian:</span>
 					<div class="radio-button" name="arm_endian">Big</div>
 					<div class="radio-button" name="arm_endian">Little</div>
 				</div>

--- a/www/style.css
+++ b/www/style.css
@@ -318,6 +318,6 @@ button {
 .link-bitbash .btn {
 	width: 100%;
 }
-#x86-dropdown, #riscv-dropdown, #ppc-dropdown {
+.archdep-custom-dropdown {
 	display: none;
 }

--- a/www/style.css
+++ b/www/style.css
@@ -210,7 +210,7 @@ button {
 	border: none;
 	padding: 5px;
 	margin: 5px;
-	width: 50px;
+	width: 110px;
 	text-align: center;
 }
 

--- a/www/ui.js
+++ b/www/ui.js
@@ -111,6 +111,7 @@ function setupWidgets() {
 	setupDropDown(document.querySelector("#x86-dropdown"), document.querySelector("#x86-dropdown-box"));
 	setupDropDown(document.querySelector("#riscv-dropdown"), document.querySelector("#riscv-dropdown-box"));
 	setupDropDown(document.querySelector("#ppc-dropdown"), document.querySelector("#ppc-dropdown-box"));
+	setupDropDown(document.querySelector("#arm-dropdown"), document.querySelector("#arm-dropdown-box"));
 	setupDropDown(document.querySelector("#examples-dropdown"), document.querySelector("#examples-dropdown-box"));
 	setupDropDown(document.querySelector("#help-dropdown"), document.querySelector("#help-dropdown-box"));
 	setupDropDown(document.querySelector("#arch-select"), document.querySelector("#arch-dropdown-box"), false, true);
@@ -144,10 +145,12 @@ function updatePageArch() {
 		document.querySelector("#arch-select-text").innerText = "Arm32";
 		document.querySelector("#menu").style.background = "rgb(19 73 64)"; // acorn computer logo
 		document.querySelector("#asm").classList.add("language-armasm2");
+		document.querySelector("#arm-dropdown").style.display = "flex";
 	} else if (ret.currentArch == ret.ARCH_ARM32_THUMB) {
 		document.querySelector("#arch-select-text").innerText = "Arm32 Thumb";
 		document.querySelector("#menu").style.background = "rgb(24 91 83)"; // acorn computer logo
 		document.querySelector("#asm").classList.add("language-armasm2");
+		document.querySelector("#arm-dropdown").style.display = "flex"; // Thumb is just ARM with less instructions.
 	} else if (ret.currentArch == ret.ARCH_RISCV) {
 		document.querySelector("#arch-select-text").innerText = "RISC-V";
 		document.querySelector("#menu").style.background = "rgb(179 148 84)"; // risc-v logo
@@ -413,6 +416,12 @@ setupRadioFromMap("ppc_bits", ret.bits, [
 	ret.bits = value;
 });
 setupRadioFromMap("ppc_endian", ret.endian, [
+	ret.BIG_ENDIAN,
+	ret.LITTLE_ENDIAN,
+], function(value) {
+	ret.endian = value;
+});
+setupRadioFromMap("arm_endian", ret.endian, [
 	ret.BIG_ENDIAN,
 	ret.LITTLE_ENDIAN,
 ], function(value) {


### PR DESCRIPTION
Thank you for the awesome tool! It's been super useful.
The only issue I've found is that it does not support BE ARM devices, which albeit rare can still sometimes be encountered in the wild.
In addition to adding the ARM BE support, I've also increased the width of the base address field, since you can't see the whole value when working with 32-bit addresses.